### PR TITLE
feat(openclaw): 接入 Sec-LLM 作为 OpenClaw Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,19 @@ npm run dev
 - `MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_DB`
 - `MAIL_USERNAME` / `MAIL_PASSWORD` / `MAIL_FROM` / `MAIL_PORT` / `MAIL_SERVER`
 - `MAIL_FROM_NAME` / `DOMAIN_URL`
+- `SEC_LLM_SKILL_API_KEY`（可选，用于 [OpenClaw Skill](#openclaw-skill-集成) 等外部调用）
 
 > 注意：`DEEPSEEK_API_KEY` 必须为真实可用密钥；否则云端对话会返回 401/400。
+
+### OpenClaw Skill 集成
+
+在 Telegram、Discord 等渠道通过 [OpenClaw](https://github.com/openclaw/openclaw) 调用 Sec-LLM 能力（威胁情报、RAG、钓鱼鉴定等）：
+
+1. 在 `backend/.env` 中设置 `SEC_LLM_SKILL_API_KEY`
+2. 将 `openclaw-skill/sec-llm` 复制到 OpenClaw 的 Skills 目录
+3. 配置 `SEC_LLM_BASE_URL` 与 `SEC_LLM_SKILL_API_KEY` 环境变量
+
+详见 [openclaw-skill/README.md](openclaw-skill/README.md)。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 <p align="center">
   <a href="https://github.com/yusichen396/Sec-LLM-3.0">GitHub 仓库</a> •
   <a href="#-快速开始">快速开始</a> •
-  <a href="#-功能特性">功能特性</a>
+  <a href="#-功能特性">功能特性</a> •
+  <a href="#openclaw-skill-集成">OpenClaw Skill</a>
 </p>
 
 一个面向网络安全场景的本地/云端 LLM 平台，集成 RAG 知识库、日志分析、威胁情报联网富化、流式对话与仪表盘统计，支持本地 Ollama 与 DeepSeek 云端模型切换。
@@ -38,6 +39,7 @@
 - 🔐 **用户认证**：JWT 认证 + bcrypt 密码加密 + 邮箱验证激活
 - 👤 **用户数据隔离**：日志记录、知识库文件、统计数据按用户隔离
 - 🧹 **临时文件清理**：`temp/` 目录定期清理（默认 24h）
+- 🤝 **OpenClaw Skill**：将 Sec-LLM 能力暴露为 OpenClaw 技能，支持 Telegram/Discord 等渠道调用
 
 ---
 
@@ -133,13 +135,86 @@ npm run dev
 
 ### OpenClaw Skill 集成
 
-在 Telegram、Discord 等渠道通过 [OpenClaw](https://github.com/openclaw/openclaw) 调用 Sec-LLM 能力（威胁情报、RAG、钓鱼鉴定等）：
+将 Sec-LLM 能力暴露为 [OpenClaw](https://github.com/openclaw/openclaw) 技能，使智能体可在 Telegram、Discord、Slack 等渠道调用威胁情报、RAG、钓鱼鉴定、源码审计等功能。
 
-1. 在 `backend/.env` 中设置 `SEC_LLM_SKILL_API_KEY`
-2. 将 `openclaw-skill/sec-llm` 复制到 OpenClaw 的 Skills 目录
-3. 配置 `SEC_LLM_BASE_URL` 与 `SEC_LLM_SKILL_API_KEY` 环境变量
+#### 前置条件
 
-详见 [openclaw-skill/README.md](openclaw-skill/README.md)。
+- Sec-LLM 后端已部署并可访问
+- OpenClaw 已安装并运行
+
+#### 配置步骤
+
+**1. 在 Sec-LLM 后端启用 Skill API Key**
+
+编辑 `backend/.env`，添加（建议使用强随机字符串）：
+
+```env
+SEC_LLM_SKILL_API_KEY=your-secure-random-key-here
+```
+
+重启 Sec-LLM 后端使配置生效。
+
+**2. 安装 Skill 到 OpenClaw**
+
+将 `sec-llm` 目录复制到 OpenClaw 的 Skills 目录：
+
+```bash
+# 默认路径（按 OpenClaw 版本可能不同）
+mkdir -p ~/.openclaw/workspace/skills
+cp -r openclaw-skill/sec-llm ~/.openclaw/workspace/skills/
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.openclaw\workspace\skills"
+Copy-Item -Recurse openclaw-skill\sec-llm "$env:USERPROFILE\.openclaw\workspace\skills\"
+```
+
+**3. 配置 OpenClaw 环境变量**
+
+在 OpenClaw 运行环境中设置（如 `~/.openclaw/.env` 或系统环境变量）：
+
+```bash
+export SEC_LLM_BASE_URL="http://localhost:8000"   # Sec-LLM 后端地址
+export SEC_LLM_SKILL_API_KEY="your-secure-random-key-here"
+```
+
+若 Sec-LLM 与 OpenClaw 不在同一主机，将 `localhost` 改为实际 IP 或域名。
+
+**4. 刷新 Skill**
+
+- 在 OpenClaw 对话中让智能体执行「刷新 skills」
+- 或重启 OpenClaw Gateway：`openclaw gateway restart`
+
+#### 支持能力
+
+| 能力         | 触发场景                     | 说明                         |
+|--------------|------------------------------|------------------------------|
+| 威胁情报     | 用户提供 IP/域名/MD5/SHA256  | 多源富化 + AI 研判报告       |
+| 钓鱼鉴定     | 用户提供邮件内容             | 分析是否为钓鱼/欺诈邮件      |
+| 源码审计     | 用户提供代码或文件路径       | 漏洞识别与修复建议           |
+| 规则生成     | 用户描述检测需求             | YARA/Suricata 等蓝队规则     |
+| 报告解析     | 用户提供 Nmap/Nessus 报告     | 转为管理层可读摘要           |
+| 安全问答/RAG | 用户提问                     | 基于知识库的安全领域问答     |
+
+#### 使用示例
+
+在 OpenClaw 接入的 Telegram、Discord 等渠道中，用户可直接用自然语言触发：
+
+- 「分析 IP 8.8.8.8 的威胁情报」
+- 「这封邮件是钓鱼吗：[粘贴邮件内容]」
+- 「审计这段 Python 代码的安全问题」
+- 「生成一个检测 Cobalt Strike 的 YARA 规则」
+- 「把这段 Nmap 报告翻译成管理层能懂的摘要」
+- 「根据知识库回答：什么是 XSS？」
+
+#### 故障排查
+
+| 现象           | 可能原因                         |
+|----------------|----------------------------------|
+| 401 Unauthorized | Skill Key 与后端 `.env` 不一致   |
+| 连接失败       | `SEC_LLM_BASE_URL` 错误或 Sec-LLM 未启动 |
+| Skill 无反应   | 未刷新/重启，Skill 未加载       |
+
+更多说明见 [openclaw-skill/README.md](openclaw-skill/README.md)。
 
 ---
 
@@ -215,6 +290,9 @@ sec-llm-local/
 │   │   ├── threat-intel-agent/  # 威胁情报自动化研判（独立一级功能）
 │   │   └── report-generation/   # 报告导出（聚合日志/对话/情报）
 │   └── lib/         # API 客户端
+├── openclaw-skill/   # OpenClaw Skill 集成
+│   ├── sec-llm/     # Skill 定义与辅助脚本
+│   └── README.md
 └── README.md
 ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import shutil
 import threading
 import time
@@ -10,7 +11,7 @@ from typing import Optional, List, Dict, Any
 os.environ['NO_PROXY'] = 'localhost,127.0.0.1'
 os.environ['no_proxy'] = 'localhost,127.0.0.1'
 
-from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, status, BackgroundTasks
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, status, BackgroundTasks, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from fastapi.responses import StreamingResponse
@@ -74,6 +75,9 @@ class Settings(BaseSettings):
     MAIL_SERVER: Optional[str] = None
     MAIL_FROM_NAME: str = "Sec-LLM Security Team"
     DOMAIN_URL: str = "http://localhost:3000"
+
+    # OpenClaw Skill 集成：API Key 认证（可选，配置后允许 X-Skill-Api-Key 调用）
+    SEC_LLM_SKILL_API_KEY: Optional[str] = None
 
     class Config:
         env_file = ".env"
@@ -347,6 +351,35 @@ async def get_current_active_user(current_user: Dict[str, Any] = Depends(get_cur
             headers={"WWW-Authenticate": "Bearer"},
         )
     return current_user
+
+
+async def get_current_user_or_skill(
+    request: Request,
+    token: Optional[str] = Depends(oauth2_scheme),
+    db=Depends(get_db),
+) -> Dict[str, Any]:
+    """支持 JWT 或 OpenClaw Skill API Key 认证。Skill Key 有效时以 admin 身份调用。"""
+    # 1. 优先检查 Skill API Key（用于 OpenClaw 等外部调用）
+    skill_key = request.headers.get("X-Skill-Api-Key")
+    if (
+        settings.SEC_LLM_SKILL_API_KEY
+        and skill_key
+        and secrets.compare_digest(skill_key, settings.SEC_LLM_SKILL_API_KEY)
+    ):
+        with db.cursor() as cursor:
+            cursor.execute("SELECT * FROM users WHERE username=%s", ("admin",))
+            admin_user = cursor.fetchone()
+        if admin_user:
+            return admin_user
+    # 2. 回退到 JWT 认证
+    user = await get_current_user(token, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="未登录、Token 已过期或 Skill API Key 无效",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user
 
 
 async def get_current_admin_user(current_user: Dict[str, Any] = Depends(get_current_active_user)) -> Dict[str, Any]:
@@ -1446,7 +1479,7 @@ def _threat_verdict(score: int) -> str:
 @app.post("/api/security-tools/phishing-analyzer")
 def phishing_analyzer(
     req: PhishingAnalyzeRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     if not req.content or not req.content.strip():
         raise HTTPException(status_code=400, detail="邮件内容不能为空")
@@ -1500,7 +1533,7 @@ def phishing_analyzer(
 @app.post("/api/security-tools/rule-generator")
 async def rule_generator(
     req: RuleGeneratorRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     if not req.requirement or not req.requirement.strip():
         raise HTTPException(status_code=400, detail="需求描述不能为空")
@@ -1595,7 +1628,7 @@ Rules:
 @app.post("/api/security-tools/code-audit")
 def code_vulnerability_scanner(
     req: CodeAuditRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     if not req.code or not req.code.strip():
         raise HTTPException(status_code=400, detail="代码内容不能为空")
@@ -1645,7 +1678,7 @@ def code_vulnerability_scanner(
 @app.post("/api/security-tools/report-explainer")
 def scan_report_explainer(
     req: ReportExplainRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     if not req.content or not req.content.strip():
         raise HTTPException(status_code=400, detail="报告内容不能为空")
@@ -1690,7 +1723,7 @@ def scan_report_explainer(
 @app.post("/api/security-tools/threat-intel/enrich")
 async def threat_intel_enrich(
     req: ThreatIntelEnrichRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     del current_user  # 保留鉴权，避免未登录调用
     ioc_raw = (req.ioc or "").strip()
@@ -1791,7 +1824,7 @@ async def threat_intel_enrich(
 @app.post("/api/security-tools/threat-intel/report")
 async def threat_intel_report(
     req: ThreatIntelReportRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     provider = get_user_provider(current_user)
     ioc = (req.ioc or "").strip()
@@ -1893,7 +1926,7 @@ async def upload_file(
     file: UploadFile = File(...),
     mode: str = "auto",
     db=Depends(get_db),
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     """
     文件上传接口
@@ -2054,7 +2087,7 @@ async def upload_file(
 @app.get("/api/knowledge/files")
 def list_knowledge_files(
     db=Depends(get_db),
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     """列出所有已学习的知识库文件"""
     with db.cursor() as cursor:
@@ -2431,7 +2464,7 @@ def _normalize_chat_role(role: str) -> str:
 @app.post("/api/chat")
 async def chat(
     req: ChatRequest,
-    current_user: Dict[str, Any] = Depends(get_current_active_user),
+    current_user: Dict[str, Any] = Depends(get_current_user_or_skill),
 ):
     active_provider = get_user_provider(current_user)
     provider_model_name = settings.OLLAMA_MODEL_NAME if active_provider == "local" else settings.DEEPSEEK_MODEL_NAME

--- a/openclaw-skill/CHANGELOG.md
+++ b/openclaw-skill/CHANGELOG.md
@@ -1,0 +1,13 @@
+# OpenClaw Skill 更新日志
+
+## 1.0.0 (2026-03)
+
+- 初始版本：Sec-LLM 作为 OpenClaw Skill
+- 支持威胁情报、钓鱼鉴定、源码审计、规则生成、报告解析、RAG 对话
+- Skill API Key 认证（X-Skill-Api-Key）
+- 辅助脚本 `call-sec-llm.sh`
+
+### 安全检查（2026-03 修订）
+
+- 后端：API Key 校验改为 `secrets.compare_digest`，防止时序攻击
+- 脚本：enrich/rule 等参数使用 jq 构建 JSON，避免特殊字符注入

--- a/openclaw-skill/README.md
+++ b/openclaw-skill/README.md
@@ -1,0 +1,90 @@
+# Sec-LLM OpenClaw Skill
+
+将 [Sec-LLM](https://github.com/yusichen396/Sec-LLM-3.0) 网络安全平台的能力暴露为 OpenClaw 技能，使智能体可在 Telegram、Discord 等渠道调用威胁情报、RAG 对话、钓鱼鉴定、源码审计等功能。
+
+## 前置条件
+
+1. **Sec-LLM 后端**已部署并可访问
+2. **OpenClaw** 已安装并运行
+3. 后端已配置 `SEC_LLM_SKILL_API_KEY`（见下方）
+
+## 配置步骤
+
+### 1. 在 Sec-LLM 后端启用 Skill API Key
+
+编辑 `backend/.env`，添加（或生成强随机字符串）：
+
+```env
+SEC_LLM_SKILL_API_KEY=your-secure-random-key-here
+```
+
+重启 Sec-LLM 后端使配置生效。
+
+### 2. 安装 Skill 到 OpenClaw
+
+将 `sec-llm` 目录复制到 OpenClaw 的 Skills 目录：
+
+```bash
+# 默认路径（按 OpenClaw 版本可能不同）
+mkdir -p ~/.openclaw/workspace/skills
+cp -r openclaw-skill/sec-llm ~/.openclaw/workspace/skills/
+
+# 或若使用 ~/.openclaw/skills
+mkdir -p ~/.openclaw/skills
+cp -r openclaw-skill/sec-llm ~/.openclaw/skills/
+```
+
+### 3. 配置环境变量
+
+在 OpenClaw 运行环境中设置：
+
+```bash
+export SEC_LLM_BASE_URL="http://localhost:8000"   # Sec-LLM 后端地址
+export SEC_LLM_SKILL_API_KEY="your-secure-random-key-here"
+```
+
+若 OpenClaw 使用 `~/.openclaw/.env` 或系统 env，可在其中添加上述变量。
+
+### 4. 刷新 Skill
+
+- 让智能体执行「刷新 skills」
+- 或重启 OpenClaw Gateway
+
+## 能力说明
+
+| 能力         | 触发场景                     | 对应 API                    |
+|--------------|------------------------------|-----------------------------|
+| 威胁情报     | 用户提供 IP/域名/MD5/SHA256  | `threat-intel/enrich` + `report` |
+| 钓鱼鉴定     | 用户提供邮件内容             | `phishing-analyzer`          |
+| 源码审计     | 用户提供代码或文件路径       | `code-audit`                 |
+| 规则生成     | 用户描述检测需求             | `rule-generator`             |
+| 报告解析     | 用户提供 Nmap/Nessus 报告    | `report-explainer`           |
+| 安全问答/RAG | 用户提问                     | `chat`                      |
+
+## 使用示例
+
+用户在 OpenClaw 对话中可这样触发：
+
+- 「分析 IP 8.8.8.8 的威胁情报」
+- 「这封邮件是钓鱼吗：[邮件内容]」
+- 「审计这段 Python 代码的安全问题」
+- 「生成一个检测 Cobalt Strike 的 YARA 规则」
+- 「把这段 Nmap 报告翻译成管理层能懂的摘要」
+- 「根据知识库回答：什么是 XSS？」
+
+## 目录结构
+
+```
+openclaw-skill/
+├── README.md           # 本说明
+└── sec-llm/
+    ├── SKILL.md        # OpenClaw Skill 定义与使用说明
+    └── scripts/
+        └── call-sec-llm.sh  # 调用 Sec-LLM 的辅助脚本
+```
+
+## 故障排查
+
+- **401 Unauthorized**：检查 `SEC_LLM_SKILL_API_KEY` 是否与后端 `.env` 一致
+- **Connection refused**：检查 `SEC_LLM_BASE_URL` 和 Sec-LLM 是否已启动
+- **Skill 未加载**：确认路径为 `~/.openclaw/workspace/skills/sec-llm`（或当前 OpenClaw 文档要求的路径），并重启 Gateway

--- a/openclaw-skill/sec-llm/SKILL.md
+++ b/openclaw-skill/sec-llm/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: sec-llm
+version: 1.0.0
+description: 调用 Sec-LLM 网络安全平台能力，包括威胁情报富化与研判、钓鱼邮件鉴定、源码审计、蓝队规则生成、扫描报告解析、RAG 知识库对话。Use when the user asks for threat intelligence on IP/domain/hash, phishing email analysis, code security audit, detection rule generation, scan report explanation, or cybersecurity knowledge query.
+author: Sec-LLM
+permissions:
+  - network:outbound
+---
+
+# Sec-LLM 网络安全技能
+
+当用户需要以下能力时，使用本 Skill 调用 Sec-LLM 平台：
+
+- **威胁情报**：对 IP、域名、MD5、SHA256 进行富化与研判
+- **钓鱼邮件鉴定**：分析邮件内容是否为钓鱼
+- **源码审计**：审计代码中的安全漏洞
+- **规则生成**：生成 YARA/Suricata 等蓝队检测规则
+- **报告解析**：将 Nmap/Nessus 等扫描报告转为可读摘要
+- **安全知识问答**：基于 RAG 知识库的安全问答（需 Sec-LLM 已上传文档）
+
+## 前置条件
+
+在 OpenClaw 运行环境中配置环境变量：
+
+- `SEC_LLM_BASE_URL`：Sec-LLM 后端地址（如 `http://localhost:8000`）
+- `SEC_LLM_SKILL_API_KEY`：与 Sec-LLM 后端 `SEC_LLM_SKILL_API_KEY` 一致的 API Key
+
+Sec-LLM 后端需在 `.env` 中设置 `SEC_LLM_SKILL_API_KEY` 并重启。
+
+## 调用方式
+
+使用 `scripts/call-sec-llm.sh` 脚本，或直接用 `curl` 调用 Sec-LLM API，请求头需包含：
+
+```
+X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}
+```
+
+## API 列表
+
+### 1. 威胁情报富化
+
+```bash
+# 富化单个 IOC（IP/域名/MD5/SHA256）
+curl -sS "${SEC_LLM_BASE_URL}/api/security-tools/threat-intel/enrich" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"ioc": "8.8.8.8", "ioc_type": "auto"}'
+```
+
+返回包含 `verdict`、`enrichment`、`source_status` 等。
+
+### 2. 威胁情报研判报告
+
+先调用 `enrich` 获取结构化结果，再调用 `report` 生成中文研判报告：
+
+```bash
+# 需要传入 enrich 的完整返回作为 enrichment
+curl -sS "${SEC_LLM_BASE_URL}/api/security-tools/threat-intel/report" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"ioc": "8.8.8.8", "detected_type": "ip", "enrichment": {...}}'
+```
+
+返回为流式文本，需完整读取后汇总给用户。
+
+### 3. 钓鱼邮件鉴定
+
+```bash
+curl -sS "${SEC_LLM_BASE_URL}/api/security-tools/phishing-analyzer" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "邮件正文内容..."}'
+```
+
+### 4. 源码审计
+
+```bash
+curl -sS "${SEC_LLM_BASE_URL}/api/security-tools/code-audit" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "代码内容...", "language": "python"}'
+```
+
+### 5. 蓝队规则生成
+
+```bash
+curl -sS "${SEC_LLM_BASE_URL}/api/security-tools/rule-generator" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"requirement": "检测 Cobalt Strike 心跳", "rule_type": "yara"}'
+```
+
+规则类型支持 `yara`、`suricata` 等。
+
+### 6. 扫描报告解析
+
+```bash
+curl -sS "${SEC_LLM_BASE_URL}/api/security-tools/report-explainer" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Nmap/Nessus 报告原文..."}'
+```
+
+### 7. 安全对话（含 RAG）
+
+```bash
+curl -sS "${SEC_LLM_BASE_URL}/api/chat" \
+  -H "X-Skill-Api-Key: ${SEC_LLM_SKILL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "用户问题", "history": [], "rag_only": true}'
+```
+
+`rag_only: true` 时仅从知识库检索回答；`false` 时允许通用对话。
+
+## 使用流程
+
+1. **威胁情报**：用户提供 IOC → 调用 `enrich` → 调用 `report`（传入 enrich 结果）→ 将报告整理给用户
+2. **其他工具**：用户提供输入 → 调用对应 API → 将 `result` 或响应正文整理给用户
+3. **安全问答**：用户提问 → 调用 `chat`（`rag_only` 按需设置）→ 流式或非流式读取后回复
+
+## 错误处理
+
+- 401：检查 `SEC_LLM_SKILL_API_KEY` 是否与后端一致
+- 连接失败：检查 `SEC_LLM_BASE_URL` 和网络
+- 400：检查请求体格式（如 `ioc`、`content` 等字段）

--- a/openclaw-skill/sec-llm/scripts/call-sec-llm.sh
+++ b/openclaw-skill/sec-llm/scripts/call-sec-llm.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Sec-LLM OpenClaw Skill 调用辅助脚本
+# 用法: ./call-sec-llm.sh <action> [args...]
+# action: enrich | phishing | code-audit | rule | report-explain | chat
+# 注: 威胁情报 report 需传入 enrich 完整 JSON，建议用 curl 直接调用
+
+set -e
+BASE_URL="${SEC_LLM_BASE_URL:-http://localhost:8000}"
+API_KEY="${SEC_LLM_SKILL_API_KEY}"
+
+if [ -z "$API_KEY" ]; then
+  echo '{"error": "SEC_LLM_SKILL_API_KEY 未设置"}'
+  exit 1
+fi
+
+ACTION="$1"
+shift || true
+
+case "$ACTION" in
+  enrich)
+    IOC="$1"
+    [ -z "$IOC" ] && echo '{"error": "需要 ioc 参数"}' && exit 1
+    BODY=$(jq -n --arg i "$IOC" '{ioc: $i, ioc_type: "auto"}' 2>/dev/null || echo "{\"ioc\": \"$(echo "$IOC" | sed 's/"/\\"/g')\", \"ioc_type\": \"auto\"}")
+    curl -sS "${BASE_URL}/api/security-tools/threat-intel/enrich" \
+      -H "X-Skill-Api-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$BODY"
+    ;;
+  phishing)
+    CONTENT="$1"
+    [ -z "$CONTENT" ] && echo '{"error": "需要邮件内容"}' && exit 1
+    # 支持从文件读取
+    if [ -f "$CONTENT" ]; then
+      BODY=$(jq -Rs '{content: .}' "$CONTENT" 2>/dev/null || echo "{\"content\": \"$(cat "$CONTENT" | sed 's/"/\\"/g' | tr '\n' ' ')\"}")
+    else
+      BODY="{\"content\": \"$CONTENT\"}"
+    fi
+    curl -sS "${BASE_URL}/api/security-tools/phishing-analyzer" \
+      -H "X-Skill-Api-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$BODY"
+    ;;
+  code-audit)
+    CODE="$1"
+    LANG="${2:-python}"
+    [ -z "$CODE" ] && echo '{"error": "需要代码内容或文件路径"}' && exit 1
+    if [ -f "$CODE" ]; then
+      CODE=$(cat "$CODE")
+    fi
+    curl -sS "${BASE_URL}/api/security-tools/code-audit" \
+      -H "X-Skill-Api-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "{\"code\": $(echo "$CODE" | jq -Rs .), \"language\": \"$LANG\"}"
+    ;;
+  rule)
+    REQ="$*"
+    [ -z "$REQ" ] && echo '{"error": "需要需求描述"}' && exit 1
+    BODY=$(jq -n --arg r "$REQ" '{requirement: $r, rule_type: "yara"}' 2>/dev/null || echo "{\"requirement\": \"$(echo "$REQ" | sed 's/"/\\"/g')\", \"rule_type\": \"yara\"}")
+    curl -sS "${BASE_URL}/api/security-tools/rule-generator" \
+      -H "X-Skill-Api-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$BODY"
+    ;;
+  report-explain)
+    CONTENT="$1"
+    [ -z "$CONTENT" ] && echo '{"error": "需要报告内容或文件路径"}' && exit 1
+    if [ -f "$CONTENT" ]; then
+      BODY=$(jq -Rs '{content: .}' "$CONTENT" 2>/dev/null || echo "{\"content\": \"$(cat "$CONTENT" | sed 's/"/\\"/g' | tr '\n' ' ')\"}")
+    else
+      BODY="{\"content\": \"$CONTENT\"}"
+    fi
+    curl -sS "${BASE_URL}/api/security-tools/report-explainer" \
+      -H "X-Skill-Api-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$BODY"
+    ;;
+  chat)
+    MSG="$*"
+    [ -z "$MSG" ] && echo '{"error": "需要消息内容"}' && exit 1
+    BODY=$(jq -n --arg m "$MSG" '{message: $m, history: [], rag_only: false}' 2>/dev/null || echo "{\"message\": \"$(echo "$MSG" | sed 's/"/\\"/g')\", \"history\": [], \"rag_only\": false}")
+    curl -sS "${BASE_URL}/api/chat" \
+      -H "X-Skill-Api-Key: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$BODY"
+    ;;
+  *)
+    echo "用法: $0 <enrich|phishing|code-audit|rule|report-explain|chat> [参数...]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## 变更概要

- **OpenClaw Skill 集成**：将 Sec-LLM 能力暴露为 OpenClaw 技能，支持在 Telegram/Discord 等渠道调用
- **后端**：新增 SEC_LLM_SKILL_API_KEY 配置，支持 X-Skill-Api-Key 请求头认证
- **安全**：使用 secrets.compare_digest 防止 API Key 时序攻击
- **Skill 包**：openclaw-skill/sec-llm 含 SKILL.md、call-sec-llm.sh、README

## 支持能力

| 能力 | 对应 API |
|------|----------|
| 威胁情报 | threat-intel/enrich + report |
| 钓鱼鉴定 | phishing-analyzer |
| 源码审计 | code-audit |
| 规则生成 | rule-generator |
| 报告解析 | report-explainer |
| RAG 对话 | chat |

详见 openclaw-skill/README.md